### PR TITLE
Adding xcape_sequence: emits a sequence of keypresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ fn main() ~ evdevs, uinput {
 }
 ```
 
+If you want to emit several keys use xcape_sequence instead of xcape.
+
+```dyon
+xcape_sequence(mut should_lshift, evt, KEY_LEFTSHIFT(), [[KEY_LEFTSHIFT(), KEY_9()], [KEY_LEFTSHIFT(), KEY_0()], [KEY_LEFT()]])
+```
+
+The above line types a pair of parentheses and moves between them, when you press the left shift key.
+
 Check out the source of the standard library in [src/stdlib.dyon](https://github.com/myfreeweb/evscript/blob/master/src/stdlib.dyon) to see how `xcape` is implemented!
 
 And you can run it like this:

--- a/src/stdlib.dyon
+++ b/src/stdlib.dyon
@@ -37,6 +37,25 @@ fn xcape(mut state: bool, evt: object, watch_key: f64, emit_key_chord: []) ~ uin
     }
 }
 
+
+fn xcape_sequence(mut state: bool, evt: object, watch_key: f64, emit_key_chord_sequence: []) ~ uinput {
+    if evt.kind == EV_KEY() {
+        if (evt.code == watch_key) && (evt.value == 1) {
+            state = true
+        } else if (evt.code == watch_key) && (evt.value == 0) {
+            if state {
+                for i len(emit_key_chord_sequence) {
+                    click_key_chord(emit_key_chord_sequence[i])
+                    sleep(0.001)
+                }
+            }
+            state = false
+        } else { // Pressed something else while holding, cancel
+            state = false
+        }
+    }
+}
+
 EV_SYN() = 0
 EV_KEY() = 1
 EV_REL() = 2


### PR DESCRIPTION
I took the freedom to add the xcape_sequence function into the stdlib. I think there might be others who consider it useful. If you think, that the stdlib should be kept lean, I can also create a new userlib file where users can add their own functions, without bloating stdlib. 