### PR TITLE
Update iteration syntax in example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fn main() ~ evdevs, uinput {
     should_rshift := false
     loop {
         evts := next_events(evdevs)
-        for i len(evts) {
+        for i {
             evt := evts[i]
             xcape(mut should_esc, evt, KEY_CAPSLOCK(), [KEY_ESC()])
             xcape(mut should_lshift, evt, KEY_LEFTSHIFT(), [KEY_LEFTSHIFT(), KEY_9()])

--- a/examples/demo.dyon
+++ b/examples/demo.dyon
@@ -13,7 +13,7 @@ fn main() ~ evdevs, uinput {
     should_rshift := false
     loop {
         evts := next_events(evdevs)
-        for i len(evts) {
+        for i {
             evt := evts[i]
             println("Event on " + device_name(evdevs[evt.device_idx]) + " | kind " +
                 str(evt.kind) + "	code " + str(evt.code) + "	value " + str(evt.value))


### PR DESCRIPTION
This is a very neat project! It's also made me aware of Dyon, which I appreciate. But I do have one issue: I see this error when running the example script in `examples/demo.dyon`:

```
$ evscript -f examples/demo.dyon -d /dev/input/event2

 --- ERROR ---
In `examples/demo.dyon`:

Type mismatch (#200):
Expected `[]`, found `{}`
16,19:         for i len(evts) {
16,19:                   ^
```

I just did a clean checkout from master to verify. Oddly the script works even though the error is displayed. With the change in this PR the example code still works, and no errors are reported.

When I built evscript Cargo downloaded dyon v0.39.0 which matches the version given in `Cargo.lock`. I tested with Rust v1.33.0 and Rust v1.41.0 with the same results.

Functions from stdlib that use the same iteration syntax as the example code did seem to work correctly without modification.

The same issue has been brought up in two other issue reports: #8 and #9.